### PR TITLE
Telegraf alpine: Support arm64

### DIFF
--- a/telegraf/1.20/alpine/Dockerfile
+++ b/telegraf/1.20/alpine/Dockerfile
@@ -6,7 +6,13 @@ RUN apk add --no-cache iputils ca-certificates net-snmp-tools procps lm_sensors 
 
 ENV TELEGRAF_VERSION 1.20.4
 
-RUN set -ex && \
+RUN ARCH= && \
+    case "$(uname -m)" in \
+        x86_64) ARCH='amd64';; \
+        aarch64) ARCH='arm64';; \
+        *) echo "Unsupported architecture: $(uname -m)"; exit 1;; \
+    esac && \
+    set -ex && \
     mkdir ~/.gnupg; \
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf; \
     apk add --no-cache --virtual .build-deps wget gnupg tar && \
@@ -15,11 +21,11 @@ RUN set -ex && \
     do \
         gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys "$key" ; \
     done && \
-    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz.asc && \
-    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
-    gpg --batch --verify telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz.asc telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz.asc && \
+    wget --no-verbose https://dl.influxdata.com/telegraf/releases/telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz && \
+    gpg --batch --verify telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz.asc telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz && \
     mkdir -p /usr/src /etc/telegraf && \
-    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}_static_linux_amd64.tar.gz && \
+    tar -C /usr/src -xzf telegraf-${TELEGRAF_VERSION}_linux_${ARCH}.tar.gz && \
     mv /usr/src/telegraf*/etc/telegraf/telegraf.conf /etc/telegraf/ && \
     mkdir /etc/telegraf/telegraf.d && \
     cp -a /usr/src/telegraf*/usr/bin/telegraf /usr/bin/ && \


### PR DESCRIPTION
Added support of telegraf:alpine arm64 platform.

Please let me know if you want me to port this into 1.19 and 1.18 too,
I'll be happy.